### PR TITLE
X11: Fix attribs not applied on leaving fullscreen

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ information on what to include when reporting a bug.
    combinaitons (#1598)
  - [X11] Bugfix: Keys pressed simultaneously with others were not always
    reported (#1112,#1415,#1472,#1616)
+ - [X11] Bugfix: Some window attributes were not applied on leaving fullscreen
  - [Wayland] Removed support for `wl_shell` (#1443)
  - [Wayland] Bugfix: The `GLFW_HAND_CURSOR` shape used the wrong image (#1432)
  - [Wayland] Bugfix: `CLOCK_MONOTONIC` was not correctly enabled

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -2485,7 +2485,11 @@ void _glfwPlatformSetWindowMonitor(_GLFWwindow* window,
     }
 
     if (window->monitor)
+    {
+        _glfwPlatformSetWindowDecorated(window, window->decorated);
+        _glfwPlatformSetWindowFloating(window, window->floating);
         releaseMonitor(window);
+    }
 
     _glfwInputWindowMonitor(window, monitor);
     updateNormalHints(window, width, height);


### PR DESCRIPTION
If the GLFW_DECORATED and/or GLFW_FLOATING window attributes were
changed while in fullscreen mode, the changes did not take effect when
the window entered windowed mode.

Bug reported on the GLFW forum.
https://discourse.glfw.org/t/turning-on-off-window-decorations-while-in-full-screen-wont-work-properly/1780